### PR TITLE
watch either src, or lib or root + call build only if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# vscode
+.vscode/
+
 # Runtime data
 pids
 *.pid

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Replace the "not-really-functionnal" npm | yarn link.
 npx watch-module /path/to/my/module
 ```
 
-watch-module will detect code changes in your module, run the `build` script and copy the code into your `node_modules` folder.
+watch-module will detect code changes in your module, run the `build` script (if available) and copy the code into your `node_modules` folder.
+wtach-module will first try to locate an `src/` directory at project root, if it is not found it will look for a `lib/` directory, if it fails too it will watch the whole rpoject from the root
 
 ### Multiple packages
 
@@ -26,16 +27,16 @@ npx watch-module /path/to/my/module ../my-other-module
 
 ### Configuration
 
-watch-module do use `yarn|npm run build` by default, but you can override this command by configuring your `package.json` file:
+watch-module do use `yarn|npm run build` by default (if it is available under the package.json's scripts key, otherwise it will not execute any command), but you can override this command by configuring your module's `package.json` file:
 
 ```json
 {
   "name": "my package",
   "scripts": {
-      "build:prod": "touch build.js"
+    "build:prod": "touch build.js"
   },
   "watch-module": {
-      "command": "yarn run build:prod"
+    "command": "yarn run build:prod"
   }
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,16 @@ async function getWatchPaths(modulePaths: string[]): Promise<string[]> {
       continue;
     } catch {}
 
+    try {
+      // then look for a lib/ dir
+      const libsPath = `${path}/libs`;
+      const stats = await fs.stat(libsPath);
+      if (stats.isDirectory()) {
+        srcPaths.push(libsPath);
+      }
+      continue;
+    } catch {}
+
     // if none of the above dirs were found, watch root path
     srcPaths.push(path);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,40 @@
 import process from 'process';
 import debounce from 'debounce';
 import chokidar from 'chokidar';
+import { promises as fs } from 'fs-extra';
 import { debug } from './logging';
 import { buildPath, restoreOldDirectories } from './build';
 import argv from './argv';
+
+async function getWatchPaths(modulePaths: string[]): Promise<string[]> {
+  const srcPaths: string[] = [];
+  for (let i = 0; i < modulePaths.length; i++) {
+    const path = modulePaths[i];
+    try {
+      // first look for an src/ dir
+      const srcPath = `${path}/src`;
+      const stats = await fs.stat(srcPath);
+      if (stats.isDirectory()) {
+        srcPaths.push(srcPath);
+      }
+      continue;
+    } catch {}
+
+    try {
+      // then look for a lib/ dir
+      const libPath = `${path}/lib`;
+      const stats = await fs.stat(libPath);
+      if (stats.isDirectory()) {
+        srcPaths.push(libPath);
+      }
+      continue;
+    } catch {}
+
+    // if none of the above dirs were found, watch root path
+    srcPaths.push(path);
+  }
+  return srcPaths;
+}
 
 function main(): void {
   debug('arguments: ', argv);
@@ -29,34 +60,37 @@ function main(): void {
     return;
   }
 
-  const srcPaths = modulePaths.map((path: string) => `${path}/src`);
+  getWatchPaths(modulePaths).then(srcPaths => {
+    chokidar
+      // One-liner for current directory, ignores .dotfiles
+      .watch(srcPaths, { ignored: /(^|[/\\])\.[^./]/ })
+      .on(
+        'all',
+        (
+          _event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir',
+          path: string
+        ) => {
+          const modulePath = modulePaths.find((tmpPath: string) => {
+            return (
+              // check if path starts with the module path or if it is the root of the module
+              path.startsWith(`${tmpPath}/`) || path.startsWith(`${tmpPath}`)
+            );
+          });
 
-  chokidar
-    // One-liner for current directory, ignores .dotfiles
-    .watch(srcPaths, { ignored: /(^|[/\\])\.[^./]/ })
-    .on(
-      'all',
-      (
-        _event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir',
-        path: string
-      ) => {
-        const modulePath = modulePaths.find((tmpPath: string) =>
-          path.startsWith(`${tmpPath}/`)
-        );
+          if (!modulePath) {
+            throw new Error(
+              'Unable to find module path. This should not happen.'
+            );
+          }
 
-        if (!modulePath) {
-          throw new Error(
-            'Unable to find module path. This should not happen.'
-          );
+          onChange(modulePath);
         }
+      );
 
-        onChange(modulePath);
-      }
-    );
-
-  process.on('SIGINT', () => {
-    Promise.all(restoreOldDirectories(modulePaths)).then(() => {
-      process.exit();
+    process.on('SIGINT', () => {
+      Promise.all(restoreOldDirectories(modulePaths)).then(() => {
+        process.exit();
+      });
     });
   });
 }


### PR DESCRIPTION
The idea is to have something more flexible

We used to force watch the src/ dir, but it is not always available, often replaced by lib/ and sometimes there is not even such a dir.
So we start by looking for src, then lib, then libs, then we watch all the files if need be (this could lead to infinite reload if there is also a build step as the files in the dist/ folder would be monitored as well)

ideally, includes and excludes should be handled by some sort of config or arguments. Today we check in the targeted module's package.json if there is a watch-module config key, maybe it should be in the main module's package.json instead, or even in a .watch-modulerc inside the main module

something like this : 
```
module.exports = {
  "my-module": {
    "includes": ["./src/"],
    "command": "build"
  },
  "my-other-module": {
    "includes": ["./lib/"],
    "command": "compile"
  },
  "my-root-module": {
    "includes": ["./"],
    "excludes": ["./dist/"]
  }
};
```

We also always called build, but it is not always present (ie: react-native modules). Do not call run build anymore if not present.