### PR TITLE
Fix excludes paths by removing trailing slash

### DIFF
--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -149,9 +149,7 @@ export function getExcludesPaths(modulePaths: string[]): string[] {
   const srcPaths: string[] = [];
   for (let i = 0; i < modulePaths.length; i++) {
     const path = modulePaths[i];
-
     const moduleConfig = getModuleConfigEntry(path);
-
     const moduleExcludes =
       moduleConfig.excludes && Array.isArray(moduleConfig.excludes)
         ? moduleConfig.excludes
@@ -159,14 +157,18 @@ export function getExcludesPaths(modulePaths: string[]): string[] {
 
     moduleExcludes.forEach((excludePath) => {
       let pathToAdd = `${path}/`;
+
       if (excludePath && excludePath !== '.') {
-        pathToAdd = `${pathToAdd}${excludePath}`;
+        pathToAdd = `${pathToAdd}${excludePath.replace(/\/+$/, '')}`;
       }
+
       if (!fs.existsSync(pathToAdd)) {
         return;
       }
+
       srcPaths.push(pathToAdd);
     });
   }
+
   return srcPaths;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ function main(): void {
   if (!includesPaths.length) {
     log('nothing to watch, exiting...');
   }
-  // return;
+
   chokidar
     // One-liner for current directory, ignores .dotfiles
     .watch(includesPaths, { ignored: [/(^|[/\\])\.[^./]/, ...excludesPaths] })


### PR DESCRIPTION
The `excludes` workflow was not working if a path contains a trailing slash. I suggest to remove trailing slash if exists.

Now all these workflows works: 
```json
"excludes": [
  "src/foo",
  "src/bar/",
  "src/baz//",
]
```