### PR TITLE
use default config for un-setted keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npx watch-module /path/to/my/module ../my-other-module
 
 ### Configuration
 
-On first launch, watch-module creates an empty configuration file to `{HOME_FOLDER}/.config/watch-module/config.json`
+On first launch, watch-module creates an empty configuration file to `{HOME_FOLDER}/.config/watch-module/watch-module.json`
 In order to force a different configuration for a specific module, you can add "per module" entries to this file :
 
 ```jsonc
@@ -44,6 +44,7 @@ In order to force a different configuration for a specific module, you can add "
   // do not watch the files in the "dist" directory
   // do not call any command before copying the files
   "my-other-module": {
+    "command": null,
     "includes": [""], // use "" or "." to watch all files
     "excludes": ["dist"]
   }
@@ -60,7 +61,7 @@ You can override this global configuration by configuring the targeted module's 
   },
   "watch-module": {
     "command": "yarn run build:prod",
-    "includes": ["src"] // if "includes" is not defined, watch-module will use "src" for retro compatibility
+    "includes": ["src"]
   }
 }
 ```
@@ -69,10 +70,15 @@ If no configuration is found for a module, watch-module falls back to the defaul
 
 ```jsonc
 {
+  "command": "yarn|npm run build", // default configs tries to detect yarn or npm
   "includes": ["src"],
-  "command": "yarn|npm run build" // default configs tries to detect yarn or npm
+  "excludes": []
 }
 ```
+
+#### Partial configuration
+
+If you overrides only some parts of the configuration, then the keys that are not overiden will use the default configuration.
 
 ## Alternatives
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -12,8 +12,9 @@ export const cwd = nodeProcess.cwd();
 /**
  * get the command to call for the package
  */
-function getModuleCommandForPath(path: string): string | void {
+function getModuleCommandForPath(path: string): string | null | undefined {
   const moduleConfig = getModuleConfigEntry(path);
+
   return moduleConfig.command;
 }
 


### PR DESCRIPTION
The fact that if you override partial configurations does set all other keys to undefined is really unusual.

For the record I got stucked with this case:

- I put a file in my root folder,
- the default `include` is `src` so I got an error message "nothing to watch, exiting",
- I did overide the `watch-module.includes` in my configuration,
- nothing did build, as the default `command` is not used anymore because I have overided only one key, and not set back the `command` to its default `yarn run build`

I thinks that it's way more understandable that changing a key will only change this and only this key to the configuration.

Moreover, if we add more configuration key with some default value, this version is more resilient, because the way we do in actually, the key will be seen as `undefined`.
